### PR TITLE
Add Docker build test workflow

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,29 @@
+name: Test Docker build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.build-all
+          platforms: linux/amd64
+          push: false
+          load: true
+

--- a/Dockerfile.build-all
+++ b/Dockerfile.build-all
@@ -16,7 +16,7 @@
 #=======================================================================================================================
 
 # Backend build (server)
-FROM golang:1.23-alpine AS backend-build
+FROM golang:1.24-alpine AS backend-build
 RUN apk add --no-cache --update git curl
 
 COPY . /go/src/comentario/


### PR DESCRIPTION
## Summary
- add CI workflow to build Docker image with Dockerfile.build-all to verify build success

## Testing
- `go test ./...` *(fails: no required module provides package)*
- `yarn test:ci` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683fce43775c832c894640af1ae4137d