### PR TITLE
Fix server port configuration

### DIFF
--- a/comentario_server.go
+++ b/comentario_server.go
@@ -49,6 +49,10 @@ func main() {
 		logger.Fatalf("Failed to post-process configuration: %v", err)
 	}
 
+	// Apply listening host and port from the parsed configuration
+	server.Host = config.ServerConfig.ListenHost
+	server.Port = config.ServerConfig.ListenPort
+
 	// Link the translations to the embedded filesystem
 	config.I18nFS = &i18nFS
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,8 @@ import (
 // ServerConfiguration stores Comentario server configuration
 type ServerConfiguration struct {
 	// Flags
+	ListenHost           string `long:"host"             description:"The IP to listen on"                     default:"localhost"                 env:"HOST"`
+	ListenPort           int    `long:"port"             description:"The port to listen on"                   default:"8080"                     env:"PORT"`
 	Verbose              []bool `short:"v" long:"verbose"   description:"Verbose logging (-vv for debug)"`
 	NoLogColours         bool   `long:"no-color"            description:"Disable log colouring"                                                            env:"NO_COLOR"`
 	BaseURL              string `long:"base-url"            description:"Server's own base URL"                      default:"http://localhost:8080"       env:"BASE_URL"`


### PR DESCRIPTION
## Summary
- support `--host` and `--port` options via `ServerConfiguration`
- apply these options when starting the server

## Testing
- `go build ./...` *(fails: no required module provides package gitlab.com/comentario/comentario/internal/api/models)*

------
https://chatgpt.com/codex/tasks/task_e_684e4a39aca4832cbdd61f98b3926a94