### PR TITLE
Update TLS docker-compose docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,41 @@ Feel free to examine the [changelog](CHANGELOG.md), but here are a few major poi
 ## Getting started
 
 Refer to [Comentario documentation](https://docs.comentario.app/en/getting-started/) to learn how to install and configure it.
+
+### Example Docker configuration with TLS
+
+Below is a minimal `docker-compose.yml` that starts Comentario over HTTPS on port 8443:
+
+```yaml
+version: '3'
+
+services:
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: comentario
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+
+  app:
+    image: registry.gitlab.com/comentario/comentario
+    command:
+      - "--scheme=https"
+      - "--tls-cert=/etc/letsencrypt/live/example.com/fullchain.pem"
+      - "--tls-key=/etc/letsencrypt/live/example.com/privkey.pem"
+      - "-v"
+    environment:
+      BASE_URL: https://example.com:8443/
+      SECRETS_FILE: "/secrets.yaml"
+      TLS_PORT: 8443
+      TLS_HOST: 0.0.0.0
+    ports:
+      - "8443:8443"
+    volumes:
+      - ./secrets.yaml:/secrets.yaml:ro
+      - /etc/letsencrypt/:/etc/letsencrypt/:ro
+```
+
+See [Docker playground](docs/content/getting-started/docker-compose.en.md) for more details.

--- a/docs/content/getting-started/docker-compose.en.md
+++ b/docs/content/getting-started/docker-compose.en.md
@@ -29,13 +29,21 @@ services:
 
   app:
     image: registry.gitlab.com/comentario/comentario
+    command:
+      - "--scheme=https"
+      - "--tls-cert=/etc/letsencrypt/live/example.com/fullchain.pem"
+      - "--tls-key=/etc/letsencrypt/live/example.com/privkey.pem"
+      - "-v"
     environment:
-      BASE_URL: http://localhost:8080/
+      BASE_URL: https://example.com:8443/
       SECRETS_FILE: "/secrets.yaml"
+      TLS_PORT: 8443
+      TLS_HOST: 0.0.0.0
     ports:
-      - "8080:80"
+      - "8443:8443"
     volumes:
       - ./secrets.yaml:/secrets.yaml:ro
+      - /etc/letsencrypt/:/etc/letsencrypt/:ro
 ```
 * `secrets.yaml` (find more details in [](/configuration/backend/secrets)):
 ```yaml
@@ -54,4 +62,4 @@ The two files must reside in the same directory. Then, start the database and th
 docker compose up
 ```
 
-Comentario will be reachable at [localhost:8080](http://localhost:8080). Just navigate to [Sign up](http://localhost:8080/en/auth/signup) and register with any email and password: you'll become a [superuser](/kb/permissions/superuser) and will be able to configure the server and add domains in the UI.
+Comentario will be reachable at [https://example.com:8443](https://example.com:8443). Just navigate to [Sign up](https://example.com:8443/en/auth/signup) and register with any email and password: you'll become a [superuser](/kb/permissions/superuser) and will be able to configure the server and add domains in the UI.


### PR DESCRIPTION
## Summary
- document a Docker Compose configuration that runs Comentario with TLS
- add the same example to README

## Testing
- `npm test` *(fails: ng not found)*
- `go test ./...` *(fails: missing gitlab.com/comentario modules)*

------
https://chatgpt.com/codex/tasks/task_e_684eac0c3310832cba93e0d9e1e25873