### PR TITLE
Add rootCA support for OIDC providers

### DIFF
--- a/docs/content/configuration/backend/secrets.en.md
+++ b/docs/content/configuration/backend/secrets.en.md
@@ -97,6 +97,8 @@ Below is a summary of the values in the secrets file.
 | `idp.oidc.[N].name`                                     | string  | OIDC provider display name                                                                  |                     |
 | `idp.oidc.[N].url`                                      | string  | OIDC provider server URL                                                                    |                     |
 | `idp.oidc.[N].scopes`                                   | array   | OIDC scopes to request (array of strings)                                                   |                     |
+| `idp.oidc.[N].rootCA`                                   | string  | Path to additional root CA certificate file (PEM) used to verify the provider
+  |                     |
 | `idp.oidc.[N].disable`                                  | boolean | Whether to forcefully disable authentication via this provider                              |                     |
 | `idp.oidc.[N].key`                                      | string  | OIDC client ID                                                                              |                     |
 | `idp.oidc.[N].secret`                                   | string  | OIDC client secret                                                                          |                     |

--- a/docs/content/configuration/idps/oidc/_index.en.md
+++ b/docs/content/configuration/idps/oidc/_index.en.md
@@ -45,6 +45,8 @@ idp:
         - email
       key:    5t02cn8y5609c28uh                     # This is your Client key
       secret: ghc02m84tgh8c2gjh                     # This is your Client secret
+      # Optional: specify a custom root CA to trust
+      rootCA: /path/to/rootCA.pem
 ...
 ```
 5. Restart Comentario.\

--- a/internal/config/oauth.go
+++ b/internal/config/oauth.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/facebook"
@@ -11,6 +13,8 @@ import (
 	"github.com/markbates/goth/providers/twitter"
 	"gitlab.com/comentario/comentario/internal/api/models"
 	"gitlab.com/comentario/comentario/internal/data"
+	"net/http"
+	"os"
 	"strings"
 )
 
@@ -172,6 +176,23 @@ func oidcConfigure() error {
 			p.Scopes...)
 		if err != nil {
 			return fmt.Errorf("failed to add OIDC provider (ID=%q): %w", p.ID, err)
+		}
+
+		// If a custom root CA is provided, configure HTTP client
+		if p.RootCA != "" {
+			rootCAs, err := x509.SystemCertPool()
+			if err != nil || rootCAs == nil {
+				rootCAs = x509.NewCertPool()
+			}
+			if certs, err := os.ReadFile(p.RootCA); err == nil {
+				if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
+					logger.Warningf("failed to append certs from %s", p.RootCA)
+				}
+			} else {
+				return fmt.Errorf("failed to load root CA %q: %w", p.RootCA, err)
+			}
+			tr := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: rootCAs}}
+			op.HTTPClient = &http.Client{Transport: tr}
 		}
 
 		// Set the name explicitly to override goth's name assigning logic that adds a suffix

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -56,6 +56,7 @@ type OIDCProvider struct {
 	Name      string   `yaml:"name"`   // Provider display name, e.g. "Keycloak"
 	URL       string   `yaml:"url"`    // OIDC server URL
 	Scopes    []string `yaml:"scopes"` // Additional scopes to request
+	RootCA    string   `yaml:"rootCA"` // Additional root CA certificate file
 }
 
 // QualifiedID returns the provider's ID prepended with the common OIDC prefix

--- a/resources/k8s/secrets.postgres.yaml
+++ b/resources/k8s/secrets.postgres.yaml
@@ -50,6 +50,7 @@ idp:
         - openid
         - profile
         - email
+      rootCA: /path/to/rootCA.pem
       key:    linkedin_key
       secret: linkedin_secret
       disable: true  # Disable to avoid being dependent on the external service availability in tests

--- a/resources/k8s/secrets.sqlite3.yaml
+++ b/resources/k8s/secrets.sqlite3.yaml
@@ -41,6 +41,7 @@ idp:
         - openid
         - profile
         - email
+        rootCA: /path/to/rootCA.pem
       key:    linkedin_key
       secret: linkedin_secret
       disable: true  # Disable to avoid being dependent on the external service availability in tests


### PR DESCRIPTION
## Summary
- allow specifying a root CA file for OIDC providers
- document new `rootCA` option
- show `rootCA` usage in example secrets files

## Testing
- `go test ./...` *(fails: no required module provides package gitlab.com/comentario/comentario/internal/api/models)*

------
https://chatgpt.com/codex/tasks/task_e_68568e0b3738832c844a57ad92562d14