### PR TITLE
Support custom CA for OIDC providers

### DIFF
--- a/docs/content/configuration/backend/secrets.en.md
+++ b/docs/content/configuration/backend/secrets.en.md
@@ -92,6 +92,7 @@ Below is a summary of the values in the secrets file.
 | `idp.oidc.[N].name`                                     | string  | OIDC provider display name                                                                    |                     |
 | `idp.oidc.[N].url`                                      | string  | OIDC provider server URL                                                                      |                     |
 | `idp.oidc.[N].scopes`                                   | array   | OIDC scopes to request (array of strings)                                                     |                     |
+| `idp.oidc.[N].caFile`                                   | string  | Path to a custom CA certificate used to trust the provider    |                     |
 | `idp.oidc.[N].disable`                                  | boolean | Whether to forcefully disable authentication via this provider                                |                     |
 | `idp.oidc.[N].key`                                      | string  | OIDC client ID                                                                                |                     |
 | `idp.oidc.[N].secret`                                   | string  | OIDC client secret                                                                            |                     |

--- a/docs/content/configuration/idps/linkedin/_index.en.md
+++ b/docs/content/configuration/idps/linkedin/_index.en.md
@@ -42,9 +42,10 @@ idp:
     name:   LinkedIn
     url:    https://www.linkedin.com/oauth/
     scopes:
-     - openid
-     - profile
-     - email
+    - openid
+    - profile
+    - email
+    caFile: /path/to/custom-ca.pem
     key:    78d26udw82x728
     secret: OfveFNVVm2l3Dkkd
 ...

--- a/docs/content/configuration/idps/oidc/_index.en.md
+++ b/docs/content/configuration/idps/oidc/_index.en.md
@@ -43,6 +43,7 @@ idp:
         # The below is an example, use the actual application scopes here
         - profile
         - email
+      caFile: /path/to/custom-ca.pem                # Optional custom CA certificate
       key:    5t02cn8y5609c28uh                     # This is your Client key
       secret: ghc02m84tgh8c2gjh                     # This is your Client secret
 ...

--- a/internal/config/oauth.go
+++ b/internal/config/oauth.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/facebook"
@@ -11,6 +13,8 @@ import (
 	"github.com/markbates/goth/providers/twitter"
 	"gitlab.com/comentario/comentario/internal/api/models"
 	"gitlab.com/comentario/comentario/internal/data"
+	"net/http"
+	"os"
 	"strings"
 )
 
@@ -172,6 +176,23 @@ func oidcConfigure() error {
 			p.Scopes...)
 		if err != nil {
 			return fmt.Errorf("failed to add OIDC provider (ID=%q): %w", p.ID, err)
+		}
+
+		// If a custom CA file is provided, set up a HTTP client with it
+		if p.CAFile != "" {
+			roots, err := x509.SystemCertPool()
+			if err != nil {
+				return fmt.Errorf("failed to load system CAs: %w", err)
+			}
+			certs, err := os.ReadFile(p.CAFile)
+			if err != nil {
+				return fmt.Errorf("failed to read CA file %q: %w", p.CAFile, err)
+			}
+			if ok := roots.AppendCertsFromPEM(certs); !ok {
+				return fmt.Errorf("failed to parse CA file %q", p.CAFile)
+			}
+			tr := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: roots}}
+			op.HTTPClient = &http.Client{Transport: tr}
 		}
 
 		// Set the name explicitly to override goth's name assigning logic that adds a suffix

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -53,6 +53,7 @@ type OIDCProvider struct {
 	Name      string   `yaml:"name"`   // Provider display name, e.g. "Keycloak"
 	URL       string   `yaml:"url"`    // OIDC server URL
 	Scopes    []string `yaml:"scopes"` // Additional scopes to request
+	CAFile    string   `yaml:"caFile"` // Optional path to a custom CA certificate
 }
 
 // QualifiedID returns the provider's ID prepended with the common OIDC prefix
@@ -94,6 +95,13 @@ func (p *OIDCProvider) validate() error {
 		return errors.New("provider server URL must be specified")
 	} else if !util.IsValidURL(p.URL, false) {
 		return errors.New("invalid provider server URL")
+	}
+
+	// CA certificate file, if specified, must be readable
+	if p.CAFile != "" {
+		if _, err := os.Stat(p.CAFile); err != nil {
+			return fmt.Errorf("cannot access CA certificate %q: %w", p.CAFile, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- allow defining a custom CA certificate for each OIDC provider
- load CA certificate file when configuring OIDC
- document new `caFile` option in secrets and provider docs

## Testing
- `go vet ./...` *(fails: no required module provides package)*
- `go test ./...` *(fails: no required module provides package)*

------
https://chatgpt.com/codex/tasks/task_e_6856917a51c8832c80bd6e4363080ef0